### PR TITLE
Update a byte of python URL

### DIFF
--- a/categories/python.json
+++ b/categories/python.json
@@ -2,7 +2,7 @@
     {
         "name": "A byte of Python",
         "description": "A useful programming book explaining the fundamentals of Python.",
-        "url": "https://swaroop-c-h.gitbook.io/byte-of-python/",
+        "url": "https://python.swaroopch.com/",
         "free": true,
         "tags": [
             "python",


### PR DESCRIPTION
The current link is no longer valid (404) - update to https://python.swaroopch.com/ instead.