### PR TITLE
Reformat JSON, Add new resources, Remove Autoprefixer from css.json

### DIFF
--- a/categories/css.json
+++ b/categories/css.json
@@ -1,15 +1,5 @@
 [
-   {
-      "name": "Autoprefixer",
-      "description": "A PostCSS plugin which parses your CSS and adds vendor prefixes",
-      "url": "https://autoprefixer.github.io/",
-      "free": true,
-      "tags": [
-         "postcss",
-         "autoformatting"
-      ]
-   },
-   {
+  {
     "name": "Clippy",
     "description": "A web tool to make css clip-paths.",
     "url": "https://bennettfeely.com/clippy/",
@@ -19,7 +9,7 @@
       "clipping"
     ]
   },
-   {
+  {
     "name": "CSS Diner",
     "description": "A fun game to learn and practice CSS selectors.",
     "url": "https://flukeout.github.io",
@@ -55,6 +45,9 @@
     "url": "https://philipwalton.github.io/solved-by-flexbox/",
     "free": true,
     "tags": [
+      "css",
+      "flex",
+      "flexbox",
       "layout",
       "centering",
       "sticky",
@@ -69,6 +62,148 @@
     "tags": [
       "learn",
       "visual"
+    ]
+  },
+  {
+    "name": "postcss-preset-env",
+    "description": "A PostCSS plugin to convert modern CSS into something most browsers can understand.",
+    "url": "https://preset-env.cssdb.org/",
+    "free": true,
+    "tags": [
+      "postcss",
+      "css",
+      "preprocessor",
+      "nesting",
+      "matches"
+    ]
+  },
+  {
+    "name": "1 Line Layouts",
+    "description": "10 Modern CSS layout and sizing techniques in a single-line of code.",
+    "url": "https://1linelayouts.glitch.me/",
+    "free": true,
+    "tags": [
+      "css",
+      "layout",
+      "tutorial",
+      "flexbox",
+      "grid"
+    ]
+  },
+  {
+    "name": "CSS Houdini Experiments",
+    "description": "Experiments with the latest CSS Houdini spec.",
+    "url": "https://css-houdini.rocks/",
+    "free": true,
+    "tags": [
+      "css",
+      "houdini",
+      "demo"
+    ]
+  },
+  {
+    "name": "Is Houdini ready yet‽",
+    "description": "Browser support chart showing current support for CSS technologies under development.",
+    "url": "https://css-houdini.rocks/",
+    "free": true,
+    "tags": [
+      "css",
+      "houdini",
+      "support",
+      "reference"
+    ]
+  },
+  {
+    "name": "CSS Houdini",
+    "description": "Explainer on new CSS “Houdini” technologies including the Layout API and Paint API.",
+    "url": "https://houdini.glitch.me/",
+    "free": true,
+    "tags": [
+      "css",
+      "houdini",
+      "learn",
+      "tutorial"
+    ]
+  },
+  {
+    "name": "CSS-Blocks",
+    "description": "Blazing fast CSS for your design systems and app components.",
+    "url": "https://css-blocks.com/",
+    "free": true,
+    "tags": [
+      "css",
+      "atomic",
+      "BEM",
+      "component",
+      "tool"
+    ]
+  },
+  {
+    "name": "Stylable CSS",
+    "description": "A CSS preprocessor that enables you to write in CSS syntax, with extensions that adhere to the spirit of CSS.",
+    "url": "https://stylable.io/",
+    "free": true,
+    "tags": [
+      "css",
+      "component",
+      "tool"
+    ]
+  },
+  {
+    "name": "A Complete Guide to Flexbox",
+    "description": "This complete guide from CSS-Tricks explains everything about flexbox.",
+    "url": "https://css-tricks.com/snippets/css/a-guide-to-flexbox/",
+    "free": true,
+    "tags": [
+      "css",
+      "layout",
+      "flex",
+      "flexbox",
+      "tutorial",
+      "reference"
+    ]
+  },
+  {
+    "name": "A Compete Guide to Grid",
+    "description": "Our comprehensive guide to CSS grid, focusing on all the settings both for the grid parent container and the grid child elements.",
+    "url": "https://css-tricks.com/snippets/css/complete-guide-grid/",
+    "free": true,
+    "tags": [
+      "css",
+      "layout",
+      "grid",
+      "learn",
+      "tutorial",
+      "reference"
+    ]
+  },
+  {
+    "name": "Grid By Example",
+    "description": "A collection of examples, video and other information to help you learn CSS Grid Layout.",
+    "url": "https://gridbyexample.com/",
+    "free": true,
+    "tags": [
+      "css",
+      "layout",
+      "grid",
+      "learn",
+      "tutorial",
+      "reference"
+    ]
+  },
+  {
+    "name": "CSSGrid.io",
+    "description": "Learn CSS grid with Wes Bos in 25 pretty good videos.",
+    "url": "https://cssgrid.io/",
+    "free": true,
+    "tags": [
+      "css",
+      "grid",
+      "learn",
+      "tutorial",
+      "video",
+      "reference",
+      "course"
     ]
   }
 ]

--- a/categories/css.json
+++ b/categories/css.json
@@ -104,7 +104,7 @@
   {
     "name": "Is Houdini ready yet‽",
     "description": "Browser support chart showing current support for CSS technologies under development.",
-    "url": "https://css-houdini.rocks/",
+    "url": "https://ishoudinireadyyet.com/",
     "free": true,
     "tags": [
       "css",

--- a/categories/fonts.json
+++ b/categories/fonts.json
@@ -7,5 +7,15 @@
     "tags": [
       "typography"
     ]
+  },
+  {
+    "name": "Font Squirrel",
+    "description": "Many free to-use fonts, as well as a webfont generator for embedding custom fonts online.",
+    "url": "https://www.fontsquirrel.com/",
+    "free": true,
+    "tags": [
+      "typography",
+      "tool"
+    ]
   }
 ]

--- a/categories/git.json
+++ b/categories/git.json
@@ -10,9 +10,9 @@
     ]
   },
   {
-    "name": "Oh Shit, Git!?!",
+    "name": "Oh S***, Git!?!",
     "description": "Quick and easy solutions to common git mistakes explained in plain english.",
-    "url": "https://ohshitgit.com/",
+    "url": "https://oh%73%68%69%74git.com/",
     "free": true,
     "tags": [
       "git"

--- a/categories/git.json
+++ b/categories/git.json
@@ -1,12 +1,21 @@
 [
-    {
-        "name": "Learn Git Branching",
-        "description": "Game-like website to learn and master git.",
-        "url": "https://learngitbranching.js.org",
-        "free": true,
-        "tags": [
-            "git",
-            "game"
-        ]
-    }
+  {
+    "name": "Learn Git Branching",
+    "description": "Game-like website to learn and master git.",
+    "url": "https://learngitbranching.js.org",
+    "free": true,
+    "tags": [
+      "git",
+      "game"
+    ]
+  },
+  {
+    "name": "Oh Shit, Git!?!",
+    "description": "Quick and easy solutions to common git mistakes explained in plain english.",
+    "url": "https://ohshitgit.com/",
+    "free": true,
+    "tags": [
+      "git"
+    ]
+  }
 ]

--- a/categories/html.json
+++ b/categories/html.json
@@ -8,5 +8,31 @@
       "learn",
       "visual"
     ]
+  },
+  {
+    "name": "HTML Living Standard",
+    "description": "This specification defines a big part of the web platform.",
+    "url": "https://html.spec.whatwg.org/multipage/",
+    "free": true,
+    "tags": [
+      "html",
+      "xml",
+      "dom",
+      "whatwg",
+      "specification",
+      "learn"
+    ]
+  },
+  {
+    "name": "HTML Living Validator",
+    "description": "A tool to help find issues with malformed or invalid HTML source code.",
+    "url": "https://html5.validator.nu/",
+    "free": true,
+    "tags": [
+      "html",
+      "xml",
+      "dom",
+      "tool"
+    ]
   }
 ]

--- a/categories/icons.json
+++ b/categories/icons.json
@@ -21,14 +21,14 @@
     ]
   },
   {
-     "name": "Nerd Fonts",
-     "description": "Lots of fonts and font-tools, programmer-ready.",
-     "url": "https://www.nerdfonts.com/",
-     "free": true,
-     "tags": [
-       "fonts",
-       "font icons",
-       "terminal fonts"
+    "name": "Nerd Fonts",
+    "description": "Lots of fonts and font-tools, programmer-ready.",
+    "url": "https://www.nerdfonts.com/",
+    "free": true,
+    "tags": [
+      "fonts",
+      "font icons",
+      "terminal fonts"
     ]
   },
   {
@@ -50,6 +50,29 @@
       "graphics",
       "simple",
       "css"
+    ]
+  },
+  {
+    "name": "Evil Icons",
+    "description": "Simple and clean SVG icon pack with the code to support Rails, Sprockets, Node.js, Gulp, Grunt and CDN.",
+    "url": "https://evil-icons.io",
+    "free": true,
+    "tags": [
+      "graphics",
+      "simple",
+      "svg"
+    ]
+  },
+  {
+    "name": "Ionicons",
+    "description": "Premium designed icons for use in web, iOS, Android, and desktop apps.",
+    "url": "https://ionicons.com",
+    "free": true,
+    "tags": [
+      "graphics",
+      "simple",
+      "font",
+      "svg"
     ]
   }
 ]

--- a/categories/javascript.json
+++ b/categories/javascript.json
@@ -43,7 +43,7 @@
     ]
   },
   {
-    "name": "HtmlDom.dev",
+    "name": "htmldom.dev",
     "description": "How to manage HTML DOM with vanilla JavaScript only.",
     "url": "https://htmldom.dev/",
     "free": true,

--- a/categories/javascript.json
+++ b/categories/javascript.json
@@ -32,6 +32,28 @@
     ]
   },
   {
+    "name": "Ditching jQuery",
+    "description": "A growing collection of native JavaScript equivalents for common jQuery tasks.",
+    "url": "https://gomakethings.com/ditching-jquery/",
+    "free": true,
+    "tags": [
+      "jquery",
+      "javascript",
+      "vanilla"
+    ]
+  },
+  {
+    "name": "HtmlDom.dev",
+    "description": "How to manage HTML DOM with vanilla JavaScript only.",
+    "url": "https://htmldom.dev/",
+    "free": true,
+    "tags": [
+      "javascript",
+      "vanilla",
+      "dom"
+    ]
+  },
+  {
     "name": "JSFiddle",
     "description": "An online playground for code demos, bug reporting, snippets and collaboration.",
     "url": "https://jsfiddle.net",

--- a/categories/python.json
+++ b/categories/python.json
@@ -1,44 +1,44 @@
 [
-    {
-        "name": "A byte of Python",
-        "description": "A useful programming book explaining the fundamentals of Python.",
-        "url": "https://python.swaroopch.com/",
-        "free": true,
-        "tags": [
-            "python",
-            "tutorial"
-        ]
-    },
-    {
-        "name": "Automate the boring stuff with Python",
-        "description": "A useful programming book explaining the fundamentals of Python.",
-        "url": "https://automatetheboringstuff.com/2e/chapter0/",
-        "free": true,
-        "tags": [
-            "python",
-            "tutorial"
-        ]
-    },
-    {
-        "name": "JetBrains PyCharm",
-        "description": "An intelligent and smart IDE used for developing Python applications",
-        "url": "https://www.jetbrains.com/pycharm/",
-        "free": true,
-        "tags": [
-            "python",
-            "ide",
-            "editor",
-            "debug"
-        ]
-    },
-    {
-        "name": "Learn X in Y minutes (Python)",
-        "description": "A rapidfire tutorial showcasing Python. Useful for learning the syntax of the language",
-        "url": "https://learnxinyminutes.com/docs/python3/",
-        "free": true,
-        "tags": [
-            "python",
-            "tutorial"
-        ]
-    }
+  {
+    "name": "A byte of Python",
+    "description": "A useful programming book explaining the fundamentals of Python.",
+    "url": "https://python.swaroopch.com/",
+    "free": true,
+    "tags": [
+      "python",
+      "tutorial"
+      ]
+  },
+  {
+    "name": "Automate the boring stuff with Python",
+    "description": "A useful programming book explaining the fundamentals of Python.",
+    "url": "https://automatetheboringstuff.com/2e/chapter0/",
+    "free": true,
+    "tags": [
+      "python",
+      "tutorial"
+    ]
+  },
+  {
+    "name": "JetBrains PyCharm",
+    "description": "An intelligent and smart IDE used for developing Python applications",
+    "url": "https://www.jetbrains.com/pycharm/",
+    "free": true,
+    "tags": [
+      "python",
+      "ide",
+      "editor",
+      "debug"
+    ]
+  },
+  {
+    "name": "Learn X in Y minutes (Python)",
+    "description": "A rapidfire tutorial showcasing Python. Useful for learning the syntax of the language",
+    "url": "https://learnxinyminutes.com/docs/python3/",
+    "free": true,
+    "tags": [
+      "python",
+      "tutorial"
+    ]
+  }
 ]

--- a/categories/software.json
+++ b/categories/software.json
@@ -1,138 +1,138 @@
 [
-    {
-        "name": "GitKraken",
-        "description": "GitKraken is a powerful Git GUI client for Windows, Mac and Linux.",
-        "url": "https://insomnia.rest/",
-        "free": true,
-        "tags": [
-            "git",
-            "source-control",
-            "development"
-        ]
-    },
-    {
-        "name": "Insomnia",
-        "description": "Insomnia is a free REST client that takes the pain out of interacting with HTTP-based APIs.",
-        "url": "https://insomnia.rest/",
-        "free": true,
-        "tags": [
-            "api",
-            "testing",
-            "development"
-        ]
-    },
-    {
-        "name": "Papercut",
-        "description": "Papercut is a simple SMTP desktop email receiver, which can be used to intercept locally-sent email.",
-        "url": "https://github.com/ChangemakerStudios/Papercut",
-        "free": true,
-        "tags": [
-            "email",
-            "testing",
-            "development"
-        ]
-    },
-    {
-        "name": "Postman",
-        "description": "Postman is a collaboration platform for API development.",
-        "url": "https://www.getpostman.com/",
-        "free": true,
-        "tags": [
-            "api",
-            "testing",
-            "development"
-        ]
-    },
-    {
-        "name": "Typora",
-        "description": "Typora is a minimal markdown editor, providing new ways for reading and writing markdown.",
-        "url": "https://www.typora.io/",
-        "free": true,
-        "tags": [
-            "markdown",
-            "wysiwyg",
-            "editor"
-        ]
-    },
-    {
-        "name": "VSCode",
-        "description": "A cross platform, language agnostic code editor.",
-        "url": "https://code.visualstudio.com/",
-        "free": true,
-        "tags": [
-            "editor",
-            "debug"
-        ]
-    },
-    {
-        "name": "Repl.it",
-        "description": "An online IDE that supports over 50 programming languages.",
-        "url": "https://repl.it/",
-        "free": true,
-        "tags": [
-            "ide",
-            "collaborative"
-        ]
-    },
-    {
-        "name": "GitHub Gist",
-        "description": "Instantly share code, notes, and snippets.",
-        "url": "https://gist.github.com",
-        "free": true,
-        "tags": [
-            "share",
-            "snippets"
-        ]
-    },
-    {
-        "name": "iTerm 2",
-        "description": "A modern replacement for Apple's Terminal with features you never knew you wanted.",
-        "url": "https://iterm2.com",
-        "free": true,
-        "tags": [
-            "terminal",
-            "macos",
-            "apple"
-        ]
-    },
-    {
-        "name": "Sequel Pro",
-        "description": "A fast, easy-to-use Mac database management application.",
-        "url": "https://sequelpro.com",
-        "free": true,
-        "tags": [
-            "sql",
-            "mysql"
-        ]
-    },
-    {
-        "name": "Cyberduck",
-        "description": "Cyberduck is a libre server and cloud storage browser for Mac and Windows.",
-        "url": "https://cyberduck.io",
-        "free": true,
-        "tags": [
-            "ftp",
-            "s3"
-        ]
-    },
-    {
-        "name": "Mountain Duck",
-        "description": "Mount server and cloud storage as a disk in Finder on macOS and the File Explorer on Windows.",
-        "url": "https://mountainduck.io",
-        "free": false,
-        "tags": [
-            "ftp",
-            "s3"
-        ]
-    },
-    {
-        "name": "CodeSandbox",
-        "description": "An instant web IDE and prototyping tool for rapid web development.",
-        "url": "https://codesandbox.io",
-        "free": true,
-        "tags": [
-            "prototype",
-            "web"
-        ]
-    }
+  {
+    "name": "GitKraken",
+    "description": "GitKraken is a powerful Git GUI client for Windows, Mac and Linux.",
+    "url": "https://insomnia.rest/",
+    "free": true,
+    "tags": [
+      "git",
+      "source-control",
+      "development"
+    ]
+  },
+  {
+    "name": "Insomnia",
+    "description": "Insomnia is a free REST client that takes the pain out of interacting with HTTP-based APIs.",
+    "url": "https://insomnia.rest/",
+    "free": true,
+    "tags": [
+      "api",
+      "testing",
+      "development"
+    ]
+  },
+  {
+    "name": "Papercut",
+    "description": "Papercut is a simple SMTP desktop email receiver, which can be used to intercept locally-sent email.",
+    "url": "https://github.com/ChangemakerStudios/Papercut",
+    "free": true,
+    "tags": [
+      "email",
+      "testing",
+      "development"
+    ]
+  },
+  {
+    "name": "Postman",
+    "description": "Postman is a collaboration platform for API development.",
+    "url": "https://www.getpostman.com/",
+    "free": true,
+    "tags": [
+      "api",
+      "testing",
+      "development"
+    ]
+  },
+  {
+    "name": "Typora",
+    "description": "Typora is a minimal markdown editor, providing new ways for reading and writing markdown.",
+    "url": "https://www.typora.io/",
+    "free": true,
+    "tags": [
+      "markdown",
+      "wysiwyg",
+      "editor"
+    ]
+  },
+  {
+    "name": "VSCode",
+    "description": "A cross platform, language agnostic code editor.",
+    "url": "https://code.visualstudio.com/",
+    "free": true,
+    "tags": [
+      "editor",
+      "debug"
+    ]
+  },
+  {
+    "name": "Repl.it",
+    "description": "An online IDE that supports over 50 programming languages.",
+    "url": "https://repl.it/",
+    "free": true,
+    "tags": [
+      "ide",
+      "collaborative"
+    ]
+  },
+  {
+    "name": "GitHub Gist",
+    "description": "Instantly share code, notes, and snippets.",
+    "url": "https://gist.github.com",
+    "free": true,
+    "tags": [
+      "share",
+      "snippets"
+    ]
+  },
+  {
+    "name": "iTerm 2",
+    "description": "A modern replacement for Apple's Terminal with features you never knew you wanted.",
+    "url": "https://iterm2.com",
+    "free": true,
+    "tags": [
+      "terminal",
+      "macos",
+      "apple"
+    ]
+  },
+  {
+    "name": "Sequel Pro",
+    "description": "A fast, easy-to-use Mac database management application.",
+    "url": "https://sequelpro.com",
+    "free": true,
+    "tags": [
+      "sql",
+      "mysql"
+    ]
+  },
+  {
+    "name": "Cyberduck",
+    "description": "Cyberduck is a libre server and cloud storage browser for Mac and Windows.",
+    "url": "https://cyberduck.io",
+    "free": true,
+    "tags": [
+      "ftp",
+      "s3"
+    ]
+  },
+  {
+    "name": "Mountain Duck",
+    "description": "Mount server and cloud storage as a disk in Finder on macOS and the File Explorer on Windows.",
+    "url": "https://mountainduck.io",
+    "free": false,
+    "tags": [
+      "ftp",
+      "s3"
+    ]
+  },
+  {
+    "name": "CodeSandbox",
+    "description": "An instant web IDE and prototyping tool for rapid web development.",
+    "url": "https://codesandbox.io",
+    "free": true,
+    "tags": [
+      "prototype",
+      "web"
+    ]
+  }
 ]


### PR DESCRIPTION
The reason I say to remove autoprefixer is browsers dont use vendor prefixes anymore except for `-webkit-*` so that makes a tool that automatically adds legacy prefixes to stuff more like "auto-mess-up-my-code-please".

Reformatted JSON to be consistent in indentation/spacing.

Added a bunch of new things, especially to CSS <3