### PR TITLE
Corrected Git Kraken link

### DIFF
--- a/categories/software.json
+++ b/categories/software.json
@@ -2,7 +2,7 @@
   {
     "name": "GitKraken",
     "description": "GitKraken is a powerful Git GUI client for Windows, Mac and Linux.",
-    "url": "https://insomnia.rest/",
+    "url": "https://www.gitkraken.com/",
     "free": true,
     "tags": [
       "git",


### PR DESCRIPTION
The GitKraken link used to point to https://insomnia.rest, I corrected this to point to https://gitkraken.com which is the actual link